### PR TITLE
Fix absolute URLs in pipelined CSS

### DIFF
--- a/system/src/Grav/Common/Assets.php
+++ b/system/src/Grav/Common/Assets.php
@@ -34,7 +34,7 @@ class Assets
     const JS_REGEX = '/.\.js$/i';
 
     /** @const Regex to match CSS urls */
-    const CSS_URL_REGEX = '{url\([\'\"]?((?!http|//).*?)[\'\"]?\)}';
+    const CSS_URL_REGEX = '{url\([\'\"]?(.*?)[\'\"]?\)}';
 
     /** @const Regex to match CSS sourcemap comments */
     const CSS_SOURCEMAP_REGEX = '{\/\*# (.*) \*\/}';
@@ -1153,6 +1153,11 @@ class Assets
 
             // ensure this is not a data url
             if (strpos($old_url, 'data:') === 0) {
+                return $matches[0];
+            }
+
+            // ensure this is not a remote url
+            if ($this->isRemoteLink($old_url)) {
                 return $matches[0];
             }
 


### PR DESCRIPTION
The way that absolute URLs get excluded during cssRewrite() doesn't cover all possible cases due to a incorrect CSS_URL_REGEX.

The current one

```
const CSS_URL_REGEX = '{url\([\'\"]?((?!http|//).*?)[\'\"]?\)}';
```

does only exclude absolute URLs that are not being wrapped inside quotes (single or double), see https://regex101.com/r/rN4sE9/1

A better one might look like this (see https://regex101.com/r/uB8zV6/1):

```
const CSS_URL_REGEX = '{url\([\'\"]?((?!([\'\"]?(http|//))).*?)[\'\"]?\)}';
```

I am not a regex pro, so I cannot exactly explain why this is correcter than the old one. Knowing that negative lookaheads are a pain to maintain, I prefer this patch as a solution. Since we're already handling data-URLs like this, I think it's only best to process accordingly with remote urls.

This matches all URLs (local, data and remote, see https://regex101.com/r/fJ0cS3/1) regardless of being wrapped inside quotes:

```
url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAAUCAYAAABvV")
url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAAUCAYAAABvV')
url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAAUCAYAAABvV)
url("grav.png")
url('grav.png')
url(grav.png)
url("font-awesome.min.css")
url('font-awesome.min.css')
url(font-awesome.min.css)
url("../../images/banner.jpg")
url('../../images/banner.jpg')
url(../../images/banner.jpg)
url("https://fonts.googleapis.com/css?family=Lato:300,400,900");
url("http://fonts.googleapis.com/css?family=Lato:300,400,900");
url("//fonts.googleapis.com/css?family=Lato:300,400,900");
url('https://fonts.googleapis.com/css?family=Lato:300,400,900');
url('http://fonts.googleapis.com/css?family=Lato:300,400,900');
url('//fonts.googleapis.com/css?family=Lato:300,400,900');
url(https://fonts.googleapis.com/css?family=Lato:300,400,900);
url(http://fonts.googleapis.com/css?family=Lato:300,400,900);
url(//fonts.googleapis.com/css?family=Lato:300,400,900);
```

and then excludes data and remote URLs afterwards.
